### PR TITLE
CP932 support

### DIFF
--- a/bin/docdiff
+++ b/bin/docdiff
@@ -37,7 +37,7 @@ ARGV.options {|o|
   o.def_option('--char', 'set resolution to char'){clo[:resolution] = "char"}
 
   o.def_option('--encoding=ENCODING',
-    possible_encodings = ['ASCII','EUC-JP','Shift_JIS','UTF-8','auto'],
+    possible_encodings = ['ASCII','EUC-JP','Shift_JIS','CP932','UTF-8','auto'],
     'specify character encoding',
     possible_encodings.join('|'), "(default is auto. try ASCII for single byte encodings such as ISO-8859-X)"
     ){|s| clo[:encoding] = (s || "auto")}
@@ -45,6 +45,7 @@ ARGV.options {|o|
   o.def_option('--iso8859x', 'same as --encoding=ASCII'){clo[:encoding] = "ASCII"}
   o.def_option('--eucjp', 'same as --encoding=EUC-JP'){clo[:encoding] = "EUC-JP"}
   o.def_option('--sjis', 'same as --encoding=Shift_JIS'){clo[:encoding] = "Shift_JIS"}
+  o.def_option('--cp932', 'same as --encoding=CP932'){clo[:encoding] = "CP932"}
   o.def_option('--utf8', 'same as --encoding=UTF-8'){clo[:encoding] = "UTF-8"}
 
   o.def_option('--eol=EOL',


### PR DESCRIPTION
- PROBREM
  When Ruby is >= 1.9, encoding of files are CP932, and files contain
  non-Shift_JIS (but CP932) characters like:
  
  ① その1

then error occurs like:

  charstring.rb:226:in `encode': "\x87@" from Shift_JIS to UTF-8 (Encoding::UndefinedConversionError)
- NOTE
  Would it be better to treat Shift_JIS as CP932?
