### PR TITLE
fix test test_anatomize_unified(TC_DocDiff_Document)

### DIFF
--- a/lib/viewdiff.rb
+++ b/lib/viewdiff.rb
@@ -334,6 +334,7 @@ def anatomize_unified_hunk(a_hunk, src_encoding, src_eol)
     body.scan(/(#{del}+)(#{add}+)|(#{del}+#{eol}?)|(#{add}+)|(#{common}+#{eol}?)|(.*#{eol}?)/m){|m|
       cf, cl, d, a, cmn, msc = m[0..5]
       [cf, cl, d, a, cmn, msc].collect{|e|
+        next if e.nil?
         e.extend(CharString)
         e.encoding, e.eol = src_encoding, src_eol
       }


### PR DESCRIPTION
Ruby 2.4.1で`rake test`を実行すると失敗します。

```
===============================================================================
Error: test_anatomize_unified(TC_DocDiff_Document): RuntimeError: can't modify frozen NilClass
/Users/maki/git/docdiff/lib/docdiff/charstring.rb:31:in `eol='
/Users/maki/git/docdiff/lib/viewdiff.rb:338:in `block (3 levels) in anatomize_unified_hunk'
/Users/maki/git/docdiff/lib/viewdiff.rb:336:in `collect'
/Users/maki/git/docdiff/lib/viewdiff.rb:336:in `block (2 levels) in anatomize_unified_hunk'
/Users/maki/git/docdiff/lib/viewdiff.rb:334:in `scan'
/Users/maki/git/docdiff/lib/viewdiff.rb:334:in `block in anatomize_unified_hunk'
/Users/maki/git/docdiff/lib/viewdiff.rb:327:in `scan'
/Users/maki/git/docdiff/lib/viewdiff.rb:327:in `anatomize_unified_hunk'
/Users/maki/git/docdiff/lib/viewdiff.rb:314:in `block in anatomize_unified'
/Users/maki/git/docdiff/lib/viewdiff.rb:311:in `scan'
/Users/maki/git/docdiff/lib/viewdiff.rb:311:in `anatomize_unified'
test/viewdiff_test.rb:903:in `test_anatomize_unified'
     900:  [:common_elt_elt,
     901:   [" ", "No ", "newline ", "at ", "end ", "of ", "file", "\n"],
     902:   [" ", "No ", "newline ", "at ", "end ", "of ", "file", "\n"]]]
  => 903:     result = @docdiff.anatomize_unified(@unified_diff)
     904:     assert_equal(expected, result)
     905:   end
     906: 
===============================================================================
E
===============================================================================
Error: test_anatomize_unified_hunk(TC_DocDiff_Document): RuntimeError: can't modify frozen NilClass
/Users/maki/git/docdiff/lib/docdiff/charstring.rb:31:in `eol='
/Users/maki/git/docdiff/lib/viewdiff.rb:338:in `block (3 levels) in anatomize_unified_hunk'
/Users/maki/git/docdiff/lib/viewdiff.rb:336:in `collect'
/Users/maki/git/docdiff/lib/viewdiff.rb:336:in `block (2 levels) in anatomize_unified_hunk'
/Users/maki/git/docdiff/lib/viewdiff.rb:334:in `scan'
/Users/maki/git/docdiff/lib/viewdiff.rb:334:in `block in anatomize_unified_hunk'
/Users/maki/git/docdiff/lib/viewdiff.rb:327:in `scan'
/Users/maki/git/docdiff/lib/viewdiff.rb:327:in `anatomize_unified_hunk'
test/viewdiff_test.rb:711:in `test_anatomize_unified_hunk'
     708:       [:common_elt_elt, ["\n"], ["\n"]],
     709:       [:common_elt_elt, [" ", "z", "\n"], [" ", "z", "\n"]]
     710:     ]
  => 711:     result = @docdiff.anatomize_unified_hunk("@@ -19,8 +20,10 @@
     712:  s
     713:  t
     714:  u
===============================================================================
```

この修正を行うととりあえず直るようです。根本的な対応になっているかは不明です…。