### PR TITLE
fix encoding error in CharString.guess_eol

### DIFF
--- a/lib/docdiff/charstring.rb
+++ b/lib/docdiff/charstring.rb
@@ -73,9 +73,14 @@ module CharString
     # returns 'CR', 'LF', 'CRLF', 'UNKNOWN'(binary), 
     # 'NONE'(1-line), or nil
     return nil if string == nil  #=> nil (argument missing)
-    eol_counts = {'CR'   => string.scan(/(\r)(?!\n)/o).size,
-                  'LF'   => string.scan(/(?:\A|[^\r])(\n)/o).size,
-                  'CRLF' => string.scan(/(\r\n)/o).size}
+    if CharString.ruby_m17n?
+      bin_string = string.force_encoding("ASCII-8BIT")
+    else
+      bin_string = string
+    end
+    eol_counts = {'CR'   => bin_string.scan(/(\r)(?!\n)/o).size,
+                  'LF'   => bin_string.scan(/(?:\A|[^\r])(\n)/o).size,
+                  'CRLF' => bin_string.scan(/(\r\n)/o).size}
     eol_counts.delete_if{|eol, count| count == 0}  # Remove missing EOL
     eols = eol_counts.keys
     eol_variety = eols.size  # numbers of flavors found


### PR DESCRIPTION
Ruby 2.4.1でShift_JISのテキストファイルを比較する際、`--sjis`オプションをつけても、以下のようなエラーが出ます。

```
/Users/maki/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/docdiff-0.5.0/lib/docdiff/charstring.rb:76:in `scan': invalid byte sequence in UTF-8 (ArgumentError)
	from /Users/maki/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/docdiff-0.5.0/lib/docdiff/charstring.rb:76:in `guess_eol'
	from /Users/maki/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/docdiff-0.5.0/bin/docdiff:157:in `<top (required)>'
	from /Users/maki/.rbenv/versions/2.4.1/bin/docdiff:22:in `load'
	from /Users/maki/.rbenv/versions/2.4.1/bin/docdiff:22:in `<main>'
```

これを修正するものです。