### PR TITLE
Accept "-" or "/dev/stdin" as filename

### DIFF
--- a/bin/docdiff
+++ b/bin/docdiff
@@ -127,10 +127,12 @@ file1_content = nil
 file2_content = nil
 raise "Try `#{File.basename($0)} --help' for more information." if ARGV[0].nil?
 raise "Specify at least 2 target files." unless ARGV[0] && ARGV[1]
+ARGV[0] = "/dev/stdin" if ARGV[0] == "-"
+ARGV[1] = "/dev/stdin" if ARGV[1] == "-"
 raise "No such file: #{ARGV[0]}." unless FileTest.exist?(ARGV[0])
 raise "No such file: #{ARGV[1]}." unless FileTest.exist?(ARGV[1])
-raise "#{ARGV[0]} is not a file." unless FileTest.file?(ARGV[0])
-raise "#{ARGV[1]} is not a file." unless FileTest.file?(ARGV[1])
+raise "#{ARGV[0]} is not readable." unless FileTest.readable?(ARGV[0])
+raise "#{ARGV[1]} is not readable." unless FileTest.readable?(ARGV[1])
 File.open(ARGV[0], "r"){|f| file1_content = f.read}
 File.open(ARGV[1], "r"){|f| file2_content = f.read}
 


### PR DESCRIPTION
I'd like to do
`git show somehash:path/file | docdiff - path/file` or
`git show somehash:path/file | docdiff /dev/stdin path/file`