### PR TITLE
Remove third argument from initializing Regexp for ruby 3.4.0 or above

### DIFF
--- a/lib/docdiff/view.rb
+++ b/lib/docdiff/view.rb
@@ -92,10 +92,18 @@ class View
   CONTEXT_PRE_LENGTH  = 32
   CONTEXT_POST_LENGTH = 32
   def apply_style_digest(tags, headfoot = true)
-    cxt_pre_pat  = Regexp.new('.{0,'+"#{CONTEXT_PRE_LENGTH}"+'}\Z',
-                              Regexp::MULTILINE, encname_for_regexp(@encoding))
-    cxt_post_pat = Regexp.new('\A.{0,'+"#{CONTEXT_POST_LENGTH}"+'}',
-                              Regexp::MULTILINE, encname_for_regexp(@encoding))
+    cxt_pre_pat =
+      if RUBY_VERSION >= "3.4.0"
+        Regexp.new('.{0,'+"#{CONTEXT_PRE_LENGTH}"+'}\Z', Regexp::MULTILINE)
+      else
+        Regexp.new('.{0,'+"#{CONTEXT_PRE_LENGTH}"+'}\Z', Regexp::MULTILINE, encname_for_regexp(@encoding))
+      end
+    cxt_post_pat =
+      if RUBY_VERSION >= "3.4.0"
+        Regexp.new('\A.{0,'+"#{CONTEXT_POST_LENGTH}"+'}', Regexp::MULTILINE)
+      else
+        Regexp.new('\A.{0,'+"#{CONTEXT_POST_LENGTH}"+'}', Regexp::MULTILINE, encname_for_regexp(@encoding))
+      end
     display = (tags and tags[:display]) || 'inline'
     result = []
     d1l = doc1_line_number = 1


### PR DESCRIPTION
Third argument for initializing Regexp is removed on ruby 3.4

https://docs.ruby-lang.org/ja/3.3/method/Regexp/s/compile.html
https://docs.ruby-lang.org/ja/3.4/method/Regexp/s/compile.html

# before
```
% grep passed *.log
charstring_test.log:100% passed
diff_test.log:100% passed
difference_test.log:100% passed
docdiff_test.log:100% passed
document_test.log:100% passed
view_test.log:80.3922% passed
viewdiff_test.log:100% passed
```

# after
```
% grep passed *.log
charstring_test.log:100% passed
diff_test.log:100% passed
difference_test.log:100% passed
docdiff_test.log:100% passed
document_test.log:100% passed
view_test.log:100% passed
viewdiff_test.log:100% passed
```