### PR TITLE
Preliminary workaround against warnings on frozen literal strings

### DIFF
--- a/lib/docdiff/encoding/en_ascii.rb
+++ b/lib/docdiff/encoding/en_ascii.rb
@@ -1,6 +1,8 @@
 # English ASCII encoding module for CharString
 # 2003- Hisashi MORITA
 
+# frozen_string_literal: false
+
 class DocDiff
 module CharString
   module ASCII

--- a/lib/docdiff/encoding/ja_eucjp.rb
+++ b/lib/docdiff/encoding/ja_eucjp.rb
@@ -1,6 +1,8 @@
 # Japanese EUC-JP encoding module for CharString
 # 2003- Hisashi MORITA
 
+# frozen_string_literal: false
+
 class DocDiff
 module CharString
   module EUC_JP

--- a/lib/docdiff/encoding/ja_sjis.rb
+++ b/lib/docdiff/encoding/ja_sjis.rb
@@ -1,6 +1,8 @@
 # Japanese Shift_JIS encoding module for CharString
 # 2003- Hisashi MORITA
 
+# frozen_string_literal: false
+
 class DocDiff
 module CharString
   module Shift_JIS

--- a/lib/docdiff/encoding/ja_utf8.rb
+++ b/lib/docdiff/encoding/ja_utf8.rb
@@ -2,6 +2,8 @@
 # Japanese UTF-8 encoding module for CharString
 # 2003- Hisashi MORITA
 
+# frozen_string_literal: false
+
 class DocDiff
 module CharString
   module UTF8

--- a/test/charstring_test.rb
+++ b/test/charstring_test.rb
@@ -1,5 +1,8 @@
 #!/usr/bin/ruby
 # -*- coding: euc-jp; -*-
+
+# frozen_string_literal: false
+
 require 'test/unit'
 require 'docdiff/charstring'
 require 'nkf'

--- a/test/docdiff_test.rb
+++ b/test/docdiff_test.rb
@@ -1,5 +1,8 @@
 #!/usr/bin/ruby
 # -*- coding: us-ascii; -*-
+
+# frozen_string_literal: false
+
 require 'test/unit'
 require 'docdiff'
 require 'nkf'

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -1,5 +1,8 @@
 #!/usr/bin/ruby
 # -*- coding: euc-jp; -*-
+
+# frozen_string_literal: false
+
 require 'test/unit'
 require 'docdiff/document'
 require 'nkf'

--- a/test/viewdiff_test.rb
+++ b/test/viewdiff_test.rb
@@ -1,5 +1,8 @@
 #!/usr/bin/ruby
 # -*- coding: euc-jp; -*-
+
+# frozen_string_literal: false
+
 require 'test/unit'
 require 'viewdiff'
 


### PR DESCRIPTION
Update with Ruby 3.4.