### PR TITLE
Set SOURCE_DATE_EPOCH when building a gem to avoid irregular timestamp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ DOCS   = doc/README.md doc/README_ja.md doc/README.html doc/README_ja.html doc/n
 DOCSRC = README.md README_ja.md doc/news.md doc/img doc/example
 TESTS  = test/*_test.rb
 DIST   = $(shell git ls-files)
+SOURCE_DATE_EPOCH = $(shell git show --quiet --format=%ct HEAD)
 
 DESTDIR =
 PREFIX  = /usr/local
@@ -64,7 +65,7 @@ dist:
 
 gem: $(PRODUCT)-$(VERSION).gem
 $(PRODUCT)-$(VERSION).gem: $(PRODUCT).gemspec
-	gem build $<
+	SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) gem build $<
 
 clean:
 	-rm -fr $(DOCS)

--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,7 @@ MD2HTML = ENV['MD2HTML'] ||= 'md2html --full-html'
 DOCS   = FileList['doc/README.md', 'doc/README_ja.md', 'doc/README.html', 'doc/README_ja.html', 'doc/news.html']
 DOCSRC = FileList['README.md', 'README_ja.md', 'doc/news.md', 'doc/img', 'doc/example']
 TESTS  = FileList['test/*_test.rb']
+ENV['SOURCE_DATE_EPOCH'] ||= `git show --quiet --format=%ct HEAD`
 
 Rake::TestTask.new do |t|
   t.test_files = TESTS


### PR DESCRIPTION
  $ tar --list --verbose -f pkg/docdiff-X.Y.Z.gem
  ... 1980-01-02 ... metadata.gz
  ... 1980-01-02 ... data.tar.gz
  ... 1980-01-02 ... checksums.yaml.gz
  $