### PR TITLE
Fix broken support for input text with CRLF

### DIFF
--- a/lib/docdiff/view.rb
+++ b/lib/docdiff/view.rb
@@ -47,10 +47,22 @@ class View
   end
 
   def escape_inside(str, tags)
-    str.gsub(tags[:inside_escape_pat]){|m| tags[:inside_escape_dic][m]}
+    str.gsub(tags[:inside_escape_pat]){|m|
+      if replacement = tags[:inside_escape_dic][m]
+        replacement
+      else
+        m
+      end
+    }
   end
   def escape_outside(str, tags)
-    str.gsub(tags[:outside_escape_pat]){|m| tags[:outside_escape_dic][m]}
+    str.gsub(tags[:outside_escape_pat]){|m|
+      if replacement = tags[:outside_escape_dic][m]
+        replacement
+      else
+        m
+      end
+    }
   end
 
   def apply_style(tags, headfoot = true)
@@ -212,7 +224,7 @@ class View
     []
   end
   TTYEscapeDic = {'ThisRandomString' => 'ThisRandomString'}
-  TTYEscapePat = /(\r\n|#{TTYEscapeDic.keys.collect{|k|Regexp.quote(k)}.join('|')})/m
+  TTYEscapePat = /(#{TTYEscapeDic.keys.collect{|k|Regexp.quote(k)}.join('|')})/m
   def tty_tags()
     {:outside_escape_dic  => TTYEscapeDic,
      :outside_escape_pat  => TTYEscapePat,
@@ -277,7 +289,7 @@ class View
   end
   HTMLEscapeDic = {'<'=>'&lt;', '>'=>'&gt;', '&'=>'&amp;', '  '=>'&nbsp;&nbsp;',
                    "\r\n" => "<br />\r\n", "\r" => "<br />\r", "\n" => "<br />\n"}
-  HTMLEscapePat = /(\r\n|#{HTMLEscapeDic.keys.collect{|k|Regexp.quote(k)}.join('|')})/m
+  HTMLEscapePat = /(#{HTMLEscapeDic.keys.collect{|k|Regexp.quote(k)}.join('|')})/m
   def html_tags()
     {:outside_escape_dic  => HTMLEscapeDic,
      :outside_escape_pat  => HTMLEscapePat,
@@ -387,7 +399,7 @@ class View
     []
   end
   WDIFFEscapeDic = {'ThisRandomString' => 'ThisRandomString'}
-  WDIFFEscapePat = /(\r\n|#{WDIFFEscapeDic.keys.collect{|k|Regexp.quote(k)}.join('|')})/m
+  WDIFFEscapePat = /(#{WDIFFEscapeDic.keys.collect{|k|Regexp.quote(k)}.join('|')})/m
   def wdiff_tags()
     {:outside_escape_dic  => WDIFFEscapeDic,
      :outside_escape_pat  => WDIFFEscapePat,
@@ -431,7 +443,7 @@ class View
   def user_header(); []; end
   def user_footer(); []; end
   UserEscapeDic = {'ThisRandomString' => 'ThisRandomString'}
-  UserEscapePat = /(\r\n|#{UserEscapeDic.keys.collect{|k|Regexp.quote(k)}.join('|')})/m
+  UserEscapePat = /(#{UserEscapeDic.keys.collect{|k|Regexp.quote(k)}.join('|')})/m
   def user_tags()
     {:outside_escape_dic  => UserEscapeDic,
      :outside_escape_pat  => UserEscapePat,

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -169,16 +169,15 @@ class TC_CLI < Test::Unit::TestCase
     assert_equal(expected, actual)
   end
 
-  # # FIXME: this test case fails as CRLf do not appear in the output
-  # def test_cli_eol_crlf()
-  #   expected =
-  #     "Hello, my name is [-Watanabe.-]{+matz.+}\r\n" +
-  #     "{+It's me who has created Ruby.  +}I am [-just another -]{+a +}Ruby [-porter.-]{+hacker.+}\r\n"
-  #   cmd = "ruby -I lib bin/docdiff --eol=CRLF --format=wdiff" +
-  #     " test/fixture/01_en_ascii_crlf.txt test/fixture/02_en_ascii_crlf.txt"
-  #   actual = `#{cmd}`
-  #   assert_equal(expected, actual)
-  # end
+  def test_cli_eol_crlf()
+    expected =
+      "Hello, my name is [-Watanabe.-]{+matz.+}\r\n" +
+      "{+It's me who has created Ruby.  +}I am [-just another -]{+a +}Ruby [-porter.-]{+hacker.+}\r\n"
+    cmd = "ruby -I lib bin/docdiff --eol=CRLF --format=wdiff" +
+      " test/fixture/01_en_ascii_crlf.txt test/fixture/02_en_ascii_crlf.txt"
+    actual = `#{cmd}`
+    assert_equal(expected, actual)
+  end
 
   def test_cli_format_html()
     expected = <<~EOS


### PR DESCRIPTION
- View#escape_outside should not gobble matched string silently
- Escape patterns do not have to include \r\n

This should fix #57.
